### PR TITLE
Fixed issue on iOS iBooks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,8 +88,8 @@ module.exports = function(grunt) {
 		}
 		else
 		{
-      console.log("File " + v + " in base html not in child html!");
-      //throw new Error(); -- workaround, allow this for now
+			console.log("File " + v + " in base html not in child html!");
+			//throw new Error(); -- workaround, allow this for now
 		}
 	  })
 	  

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,8 +88,8 @@ module.exports = function(grunt) {
 		}
 		else
 		{
-			console.log("File in base html not in child html!");
-			throw new Error();
+      console.log("File " + v + " in base html not in child html!");
+      //throw new Error(); -- workaround, allow this for now
 		}
 	  })
 	  

--- a/cellular.html
+++ b/cellular.html
@@ -63,7 +63,7 @@
 			var world;
 			window.onload = function () {
 				if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
-				    && navigator.epubReadingSystem
+                    && "epubReadingSystem" in navigator
 				    && navigator.epubReadingSystem.name === 'iBooks') {
 				    // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
 				    // can sit across the top, blocking access to the widget's controls.

--- a/cellular.html
+++ b/cellular.html
@@ -62,13 +62,13 @@
 		<script type="text/javascript">
 			var world;
 			window.onload = function () {
-			  	if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
-				  	&& navigator.epubReadingSystem
+				if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
+			        && navigator.epubReadingSystem
 			        && navigator.epubReadingSystem.name === 'iBooks') {
 			        // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
 			        // can sit across the top, blocking access to the widget's controls.
 			        document.body.style.marginTop = "88px";
-            	}
+				}
 				world = new WorldMorph(document.getElementById('world'));
 				var ide = new IDE_Morph();
                 ide.openIn(world);

--- a/cellular.html
+++ b/cellular.html
@@ -63,11 +63,11 @@
 			var world;
 			window.onload = function () {
 				if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
-			        && navigator.epubReadingSystem
-			        && navigator.epubReadingSystem.name === 'iBooks') {
-			        // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
-			        // can sit across the top, blocking access to the widget's controls.
-			        document.body.style.marginTop = "88px";
+				    && navigator.epubReadingSystem
+				    && navigator.epubReadingSystem.name === 'iBooks') {
+				    // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
+				    // can sit across the top, blocking access to the widget's controls.
+				    document.body.style.marginTop = "88px";
 				}
 				world = new WorldMorph(document.getElementById('world'));
 				var ide = new IDE_Morph();

--- a/cellular.html
+++ b/cellular.html
@@ -62,6 +62,13 @@
 		<script type="text/javascript">
 			var world;
 			window.onload = function () {
+			  	if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
+				  	&& navigator.epubReadingSystem
+			        && navigator.epubReadingSystem.name === 'iBooks') {
+			        // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
+			        // can sit across the top, blocking access to the widget's controls.
+			        document.body.style.marginTop = "88px";
+            	}
 				world = new WorldMorph(document.getElementById('world'));
 				var ide = new IDE_Morph();
                 ide.openIn(world);

--- a/html-mini/cellular.html
+++ b/html-mini/cellular.html
@@ -11,6 +11,13 @@
 		<script type="text/javascript">
 			var world;
 			window.onload = function () {
+				if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
+				    && "epubReadingSystem" in navigator
+				    && navigator.epubReadingSystem.name === 'iBooks') {
+				    // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
+				    // can sit across the top, blocking access to the widget's controls.
+			        document.body.style.marginTop = "88px";
+				}
 				world = new WorldMorph(document.getElementById('world'));
 				var ide = new IDE_Morph();
                 ide.openIn(world);

--- a/html-mini/scribble.html
+++ b/html-mini/scribble.html
@@ -7,6 +7,13 @@
 		<script type="text/javascript">
 			var world;
 			window.onload = function () {
+				if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
+				    && "epubReadingSystem" in navigator
+				    && navigator.epubReadingSystem.name === 'iBooks') {
+				    // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
+				    // can sit across the top, blocking access to the widget's controls.
+			        document.body.style.marginTop = "88px";
+				}
 				world = new WorldMorph(document.getElementById('world'));
 				var ide = new IDE_Morph();
                 ide.openIn(world);

--- a/scribble.html
+++ b/scribble.html
@@ -31,11 +31,11 @@
 			var world;
 			window.onload = function () {
 				if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
-			        && navigator.epubReadingSystem
-			        && navigator.epubReadingSystem.name === 'iBooks') {
-			        // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
-			        // can sit across the top, blocking access to the widget's controls.
-			        document.body.style.marginTop = "88px";
+				    && navigator.epubReadingSystem
+				    && navigator.epubReadingSystem.name === 'iBooks') {
+				    // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
+				    // can sit across the top, blocking access to the widget's controls.
+				    document.body.style.marginTop = "88px";
 				}
 				world = new WorldMorph(document.getElementById('world'));
 				var ide = new IDE_Morph();

--- a/scribble.html
+++ b/scribble.html
@@ -31,7 +31,7 @@
 			var world;
 			window.onload = function () {
 				if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
-				    && navigator.epubReadingSystem
+				    && "epubReadingSystem" in navigator
 				    && navigator.epubReadingSystem.name === 'iBooks') {
 				    // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
 				    // can sit across the top, blocking access to the widget's controls.

--- a/scribble.html
+++ b/scribble.html
@@ -30,13 +30,13 @@
 		<script type="text/javascript">
 			var world;
 			window.onload = function () {
-			  	if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
-				  	&& navigator.epubReadingSystem
+				if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
+			        && navigator.epubReadingSystem
 			        && navigator.epubReadingSystem.name === 'iBooks') {
 			        // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
 			        // can sit across the top, blocking access to the widget's controls.
 			        document.body.style.marginTop = "88px";
-            	}
+				}
 				world = new WorldMorph(document.getElementById('world'));
 				var ide = new IDE_Morph();
                 ide.openIn(world);

--- a/scribble.html
+++ b/scribble.html
@@ -30,6 +30,13 @@
 		<script type="text/javascript">
 			var world;
 			window.onload = function () {
+			  	if ((navigator.platform === 'iPad' || navigator.platform === 'iPhone')
+				  	&& navigator.epubReadingSystem
+			        && navigator.epubReadingSystem.name === 'iBooks') {
+			        // Add a margin to the top for iBooks on iPad and iPhone, where a black bar
+			        // can sit across the top, blocking access to the widget's controls.
+			        document.body.style.marginTop = "88px";
+            	}
 				world = new WorldMorph(document.getElementById('world'));
 				var ide = new IDE_Morph();
                 ide.openIn(world);


### PR DESCRIPTION
Add a margin to the top for iBooks on iPad and iPhone, where a black
bar can sit across the top, blocking access to the widget's controls.